### PR TITLE
Fixed menu_location not returning a Json bug

### DIFF
--- a/api-controllers/menus.php
+++ b/api-controllers/menus.php
@@ -63,7 +63,7 @@ class JSON_API_Menus_Controller {
 						// This is the correct menu
 						$menuid = $menu->slug;
 
-						var_dump($menu->slug);
+						//var_dump($menu->slug);
 
 						// Get the items for this menu
 						$menu_items = get_nav_items($menuid);


### PR DESCRIPTION
menu_locations now returns a proper Json object instead of a string and json
